### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://github.com/smol-rs/async-net"
 documentation = "https://docs.rs/async-net"
 keywords = ["networking", "uds", "mio", "reactor", "std"]
 categories = ["asynchronous", "network-programming", "os"]
-readme = "README.md"
 
 [dependencies]
 async-io = "1.0.0"


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field.