### PR TITLE
Fix clippy::from_over_into lint

### DIFF
--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -227,9 +227,9 @@ impl TryFrom<std::net::TcpListener> for TcpListener {
     }
 }
 
-impl Into<Arc<Async<std::net::TcpListener>>> for TcpListener {
-    fn into(self) -> Arc<Async<std::net::TcpListener>> {
-        self.inner
+impl From<TcpListener> for Arc<Async<std::net::TcpListener>> {
+    fn from(val: TcpListener) -> Self {
+        val.inner
     }
 }
 
@@ -553,9 +553,9 @@ impl From<Async<std::net::TcpStream>> for TcpStream {
     }
 }
 
-impl Into<Arc<Async<std::net::TcpStream>>> for TcpStream {
-    fn into(self) -> Arc<Async<std::net::TcpStream>> {
-        self.inner
+impl From<TcpStream> for Arc<Async<std::net::TcpStream>> {
+    fn from(val: TcpStream) -> Self {
+        val.inner
     }
 }
 

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -610,9 +610,9 @@ impl TryFrom<std::net::UdpSocket> for UdpSocket {
     }
 }
 
-impl Into<Arc<Async<std::net::UdpSocket>>> for UdpSocket {
-    fn into(self) -> Arc<Async<std::net::UdpSocket>> {
-        self.inner
+impl From<UdpSocket> for Arc<Async<std::net::UdpSocket>> {
+    fn from(val: UdpSocket) -> Self {
+        val.inner
     }
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -159,9 +159,9 @@ impl TryFrom<std::os::unix::net::UnixListener> for UnixListener {
     }
 }
 
-impl Into<Arc<Async<std::os::unix::net::UnixListener>>> for UnixListener {
-    fn into(self) -> Arc<Async<std::os::unix::net::UnixListener>> {
-        self.inner
+impl From<UnixListener> for Arc<Async<std::os::unix::net::UnixListener>> {
+    fn from(val: UnixListener) -> Self {
+        val.inner
     }
 }
 
@@ -358,9 +358,9 @@ impl TryFrom<std::os::unix::net::UnixStream> for UnixStream {
     }
 }
 
-impl Into<Arc<Async<std::os::unix::net::UnixStream>>> for UnixStream {
-    fn into(self) -> Arc<Async<std::os::unix::net::UnixStream>> {
-        self.inner
+impl From<UnixStream> for Arc<Async<std::os::unix::net::UnixStream>> {
+    fn from(val: UnixStream) -> Self {
+        val.inner
     }
 }
 
@@ -727,9 +727,9 @@ impl TryFrom<std::os::unix::net::UnixDatagram> for UnixDatagram {
     }
 }
 
-impl Into<Arc<Async<std::os::unix::net::UnixDatagram>>> for UnixDatagram {
-    fn into(self) -> Arc<Async<std::os::unix::net::UnixDatagram>> {
-        self.inner
+impl From<UnixDatagram> for Arc<Async<std::os::unix::net::UnixDatagram>> {
+    fn from(val: UnixDatagram) -> Self {
+        val.inner
     }
 }
 


### PR DESCRIPTION
```
warning: an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true
   --> src/tcp.rs:231:1
    |
231 | impl Into<Arc<Async<std::net::TcpListener>>> for TcpListener {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(clippy::from_over_into)]` on by default
    = help: consider to implement `From` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into
```