### PR TITLE
Bump to v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 1.6.0
+
+- Add `From` impls for conversion into inner networking types `Arc<Async<T>>`. (#12)
+- Optimize allocations in Listeners. (#11)
+
 # Version 1.5.0
 
 - Add `Into` impls for conversion into inner networking types `Arc<Async<T>>`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "async-net"
-version = "1.5.0"
+# When publishing a new version:
+# - Update CHANGELOG.md
+# - Create "v1.x.y" git tag
+version = "1.6.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 description = "Async networking primitives for TCP/UDP/Unix communication"


### PR DESCRIPTION
Changes:

- Add `From` impls for conversion into inner networking types `Arc<Async<T>>`. (#12)
- Optimize allocations in Listeners. (#11)