### PR TITLE
Remove boxed futures from TcpStream and UnixStream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["networking", "uds", "mio", "reactor", "std"]
 categories = ["asynchronous", "network-programming", "os"]
 
 [dependencies]
-async-io = "1.0.0"
+async-io = "1.5.0"
 blocking = "1.0.0"
 fastrand = "1.3.5"
 futures-lite = "1.11.0"

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -303,8 +303,8 @@ impl fmt::Debug for Incoming<'_> {
 /// ```
 pub struct TcpStream {
     inner: Arc<Async<std::net::TcpStream>>,
-    readable: Option<Pin<Box<dyn Future<Output = io::Result<()>> + Send + Sync>>>,
-    writable: Option<Pin<Box<dyn Future<Output = io::Result<()>> + Send + Sync>>>,
+    readable: Option<async_io::Readable>,
+    writable: Option<async_io::Writable>,
 }
 
 impl UnwindSafe for TcpStream {}
@@ -599,13 +599,12 @@ impl AsyncRead for TcpStream {
 
             // Initialize the future to wait for readiness.
             if self.readable.is_none() {
-                let inner = self.inner.clone();
-                self.readable = Some(Box::pin(async move { inner.readable().await }));
+                self.readable = Some(self.inner.readable());
             }
 
             // Poll the future for readiness.
             if let Some(f) = &mut self.readable {
-                let res = ready!(f.as_mut().poll(cx));
+                let res = ready!(Pin::new(f).poll(cx));
                 self.readable = None;
                 res?;
             }
@@ -631,13 +630,12 @@ impl AsyncWrite for TcpStream {
 
             // Initialize the future to wait for readiness.
             if self.writable.is_none() {
-                let inner = self.inner.clone();
-                self.writable = Some(Box::pin(async move { inner.writable().await }));
+                self.writable = Some(self.inner.writable());
             }
 
             // Poll the future for readiness.
             if let Some(f) = &mut self.writable {
-                let res = ready!(f.as_mut().poll(cx));
+                let res = ready!(Pin::new(f).poll(cx));
                 self.writable = None;
                 res?;
             }
@@ -657,13 +655,12 @@ impl AsyncWrite for TcpStream {
 
             // Initialize the future to wait for readiness.
             if self.writable.is_none() {
-                let inner = self.inner.clone();
-                self.writable = Some(Box::pin(async move { inner.writable().await }));
+                self.writable = Some(self.inner.writable());
             }
 
             // Poll the future for readiness.
             if let Some(f) = &mut self.writable {
-                let res = ready!(f.as_mut().poll(cx));
+                let res = ready!(Pin::new(f).poll(cx));
                 self.writable = None;
                 res?;
             }
@@ -691,13 +688,12 @@ impl AsyncWrite for TcpStream {
 
             // Initialize the future to wait for readiness.
             if self.writable.is_none() {
-                let inner = self.inner.clone();
-                self.writable = Some(Box::pin(async move { inner.writable().await }));
+                self.writable = Some(self.inner.writable());
             }
 
             // Poll the future for readiness.
             if let Some(f) = &mut self.writable {
-                let res = ready!(f.as_mut().poll(cx));
+                let res = ready!(Pin::new(f).poll(cx));
                 self.writable = None;
                 res?;
             }


### PR DESCRIPTION
~~depend on https://github.com/smol-rs/async-io/pull/64~~ ~~UPD: released async-io 1.5.0~~ UPD2: yanked 1.5.0

fyi @erickt, @Kestrer, @yoshuawuyts, https://github.com/async-rs/async-std/issues/969