### PR TITLE
Use Async::{readable_owned, writable_owned}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["networking", "uds", "mio", "reactor", "std"]
 categories = ["asynchronous", "network-programming", "os"]
 
 [dependencies]
-async-io = "1.5.0"
+async-io = "1.6.0"
 blocking = "1.0.0"
 fastrand = "1.3.5"
 futures-lite = "1.11.0"

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -303,8 +303,8 @@ impl fmt::Debug for Incoming<'_> {
 /// ```
 pub struct TcpStream {
     inner: Arc<Async<std::net::TcpStream>>,
-    readable: Option<async_io::Readable>,
-    writable: Option<async_io::Writable>,
+    readable: Option<async_io::ReadableOwned<std::net::TcpStream>>,
+    writable: Option<async_io::WritableOwned<std::net::TcpStream>>,
 }
 
 impl UnwindSafe for TcpStream {}
@@ -599,7 +599,7 @@ impl AsyncRead for TcpStream {
 
             // Initialize the future to wait for readiness.
             if self.readable.is_none() {
-                self.readable = Some(self.inner.readable());
+                self.readable = Some(self.inner.clone().readable_owned());
             }
 
             // Poll the future for readiness.
@@ -630,7 +630,7 @@ impl AsyncWrite for TcpStream {
 
             // Initialize the future to wait for readiness.
             if self.writable.is_none() {
-                self.writable = Some(self.inner.writable());
+                self.writable = Some(self.inner.clone().writable_owned());
             }
 
             // Poll the future for readiness.
@@ -655,7 +655,7 @@ impl AsyncWrite for TcpStream {
 
             // Initialize the future to wait for readiness.
             if self.writable.is_none() {
-                self.writable = Some(self.inner.writable());
+                self.writable = Some(self.inner.clone().writable_owned());
             }
 
             // Poll the future for readiness.
@@ -688,7 +688,7 @@ impl AsyncWrite for TcpStream {
 
             // Initialize the future to wait for readiness.
             if self.writable.is_none() {
-                self.writable = Some(self.inner.writable());
+                self.writable = Some(self.inner.clone().writable_owned());
             }
 
             // Poll the future for readiness.

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -234,8 +234,8 @@ impl fmt::Debug for Incoming<'_> {
 /// ```
 pub struct UnixStream {
     inner: Arc<Async<std::os::unix::net::UnixStream>>,
-    readable: Option<async_io::Readable>,
-    writable: Option<async_io::Writable>,
+    readable: Option<async_io::ReadableOwned<std::os::unix::net::UnixStream>>,
+    writable: Option<async_io::WritableOwned<std::os::unix::net::UnixStream>>,
 }
 
 impl UnwindSafe for UnixStream {}
@@ -396,7 +396,7 @@ impl AsyncRead for UnixStream {
 
             // Initialize the future to wait for readiness.
             if self.readable.is_none() {
-                self.readable = Some(self.inner.readable());
+                self.readable = Some(self.inner.clone().readable_owned());
             }
 
             // Poll the future for readiness.
@@ -427,7 +427,7 @@ impl AsyncWrite for UnixStream {
 
             // Initialize the future to wait for readiness.
             if self.writable.is_none() {
-                self.writable = Some(self.inner.writable());
+                self.writable = Some(self.inner.clone().writable_owned());
             }
 
             // Poll the future for readiness.
@@ -452,7 +452,7 @@ impl AsyncWrite for UnixStream {
 
             // Initialize the future to wait for readiness.
             if self.writable.is_none() {
-                self.writable = Some(self.inner.writable());
+                self.writable = Some(self.inner.clone().writable_owned());
             }
 
             // Poll the future for readiness.


### PR DESCRIPTION
This replaces #15 that depends on yanked https://github.com/smol-rs/async-io/pull/64.

~~Depend on https://github.com/smol-rs/async-io/pull/66.~~