### PR TITLE
Add I/O-safe traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ async-io = "1.6.0"
 blocking = "1.0.0"
 futures-lite = "1.11.0"
 
-[features]
-io_safety = []
+[build-dependencies]
+autocfg = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ exclude = ["/.*"]
 async-io = "1.6.0"
 blocking = "1.0.0"
 futures-lite = "1.11.0"
+
+[features]
+io_safety = []

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,18 @@
+const TEST_EXPR: &str = "{
+#[cfg(unix)]
+fn _test<I: std::os::unix::io::AsFd>(_: I) {}
+#[cfg(unix)]
+fn _test2(_: std::os::unix::io::OwnedFd) {}
+#[cfg(windows)]
+fn _test<I: std::os::windows::io::AsSocket>(_: I) {}
+#[cfg(windows)]
+fn _test2(_: std::os::windows::io::OwnedSocket) {}
+}";
+
+fn main() {
+    let cfg = autocfg::new();
+    
+    if cfg.probe_expression(TEST_EXPR) {
+        autocfg::emit("has_io_safety");
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -1,18 +1,16 @@
-const TEST_EXPR: &str = "{
-#[cfg(unix)]
-fn _test<I: std::os::unix::io::AsFd>(_: I) {}
-#[cfg(unix)]
-fn _test2(_: std::os::unix::io::OwnedFd) {}
-#[cfg(windows)]
-fn _test<I: std::os::windows::io::AsSocket>(_: I) {}
-#[cfg(windows)]
-fn _test2(_: std::os::windows::io::OwnedSocket) {}
-}";
-
 fn main() {
-    let cfg = autocfg::new();
+    let cfg = match autocfg::AutoCfg::new() {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            println!(
+                "cargo-warning=async-net: failed to detect compiler features: {}",
+                e
+            );
+            return;
+        }
+    };
 
-    if cfg.probe_expression(TEST_EXPR) {
-        autocfg::emit("has_io_safety");
+    if !cfg.probe_rustc_version(1, 63) {
+        autocfg::emit("async_net_no_io_safety");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,7 @@ fn _test2(_: std::os::windows::io::OwnedSocket) {}
 
 fn main() {
     let cfg = autocfg::new();
-    
+
     if cfg.probe_expression(TEST_EXPR) {
         autocfg::emit("has_io_safety");
     }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -2,13 +2,13 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::io::{self, IoSlice, Read as _, Write as _};
 use std::net::{Shutdown, SocketAddr};
-#[cfg(all(has_io_safety, unix))]
+#[cfg(all(not(async_net_no_io_safety), unix))]
 use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, RawSocket};
-#[cfg(all(has_io_safety, windows))]
+#[cfg(all(not(async_net_no_io_safety), windows))]
 use std::os::windows::io::{AsSocket, BorrowedSocket, OwnedSocket};
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::pin::Pin;
@@ -244,14 +244,14 @@ impl AsRawFd for TcpListener {
     }
 }
 
-#[cfg(all(has_io_safety, unix))]
+#[cfg(all(not(async_net_no_io_safety), unix))]
 impl AsFd for TcpListener {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.inner.get_ref().as_fd()
     }
 }
 
-#[cfg(all(has_io_safety, unix))]
+#[cfg(all(not(async_net_no_io_safety), unix))]
 impl TryFrom<OwnedFd> for TcpListener {
     type Error = io::Error;
 
@@ -267,14 +267,14 @@ impl AsRawSocket for TcpListener {
     }
 }
 
-#[cfg(all(has_io_safety, windows))]
+#[cfg(all(not(async_net_no_io_safety), windows))]
 impl AsSocket for TcpListener {
     fn as_socket(&self) -> BorrowedSocket<'_> {
         self.inner.get_ref().as_socket()
     }
 }
 
-#[cfg(all(has_io_safety, windows))]
+#[cfg(all(not(async_net_no_io_safety), windows))]
 impl TryFrom<OwnedSocket> for TcpListener {
     type Error = io::Error;
 
@@ -610,14 +610,14 @@ impl AsRawFd for TcpStream {
     }
 }
 
-#[cfg(all(has_io_safety, unix))]
+#[cfg(all(not(async_net_no_io_safety), unix))]
 impl AsFd for TcpStream {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.inner.get_ref().as_fd()
     }
 }
 
-#[cfg(all(has_io_safety, unix))]
+#[cfg(all(not(async_net_no_io_safety), unix))]
 impl TryFrom<OwnedFd> for TcpStream {
     type Error = io::Error;
 
@@ -633,14 +633,14 @@ impl AsRawSocket for TcpStream {
     }
 }
 
-#[cfg(all(has_io_safety, windows))]
+#[cfg(all(not(async_net_no_io_safety), windows))]
 impl AsSocket for TcpStream {
     fn as_socket(&self) -> BorrowedSocket<'_> {
         self.inner.get_ref().as_socket()
     }
 }
 
-#[cfg(all(has_io_safety, windows))]
+#[cfg(all(not(async_net_no_io_safety), windows))]
 impl TryFrom<OwnedSocket> for TcpStream {
     type Error = io::Error;
 

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -2,10 +2,14 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::io::{self, IoSlice, Read as _, Write as _};
 use std::net::{Shutdown, SocketAddr};
+#[cfg(all(feature = "io_safety", unix))]
+use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, RawSocket};
+#[cfg(all(feature = "io_safety", windows))]
+use std::os::windows::io::{AsSocket, BorrowedSocket, OwnedSocket};
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -240,10 +244,42 @@ impl AsRawFd for TcpListener {
     }
 }
 
+#[cfg(all(feature = "io_safety", unix))]
+impl AsFd for TcpListener {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.inner.get_ref().as_fd()
+    }
+}
+
+#[cfg(all(feature = "io_safety", unix))]
+impl TryFrom<OwnedFd> for TcpListener {
+    type Error = io::Error;
+
+    fn try_from(value: OwnedFd) -> Result<Self, Self::Error> {
+        Self::try_from(std::net::TcpListener::from(value))
+    }
+}
+
 #[cfg(windows)]
 impl AsRawSocket for TcpListener {
     fn as_raw_socket(&self) -> RawSocket {
         self.inner.as_raw_socket()
+    }
+}
+
+#[cfg(all(feature = "io_safety", windows))]
+impl AsSocket for TcpListener {
+    fn as_socket(&self) -> BorrowedSocket<'_> {
+        self.inner.get_ref().as_socket()
+    }
+}
+
+#[cfg(all(feature = "io_safety", windows))]
+impl TryFrom<OwnedSocket> for TcpListener {
+    type Error = io::Error;
+
+    fn try_from(value: OwnedSocket) -> Result<Self, Self::Error> {
+        Self::try_from(std::net::TcpListener::from(value))
     }
 }
 
@@ -574,10 +610,42 @@ impl AsRawFd for TcpStream {
     }
 }
 
+#[cfg(all(feature = "io_safety", unix))]
+impl AsFd for TcpStream {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.inner.get_ref().as_fd()
+    }
+}
+
+#[cfg(all(feature = "io_safety", unix))]
+impl TryFrom<OwnedFd> for TcpStream {
+    type Error = io::Error;
+
+    fn try_from(value: OwnedFd) -> Result<Self, Self::Error> {
+        Self::try_from(std::net::TcpStream::from(value))
+    }
+}
+
 #[cfg(windows)]
 impl AsRawSocket for TcpStream {
     fn as_raw_socket(&self) -> RawSocket {
         self.inner.as_raw_socket()
+    }
+}
+
+#[cfg(all(feature = "io_safety", windows))]
+impl AsSocket for TcpStream {
+    fn as_socket(&self) -> BorrowedSocket<'_> {
+        self.inner.get_ref().as_socket()
+    }
+}
+
+#[cfg(all(feature = "io_safety", windows))]
+impl TryFrom<OwnedSocket> for TcpStream {
+    type Error = io::Error;
+
+    fn try_from(value: OwnedSocket) -> Result<Self, Self::Error> {
+        Self::try_from(std::net::TcpStream::from(value))
     }
 }
 

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -2,13 +2,13 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::io::{self, IoSlice, Read as _, Write as _};
 use std::net::{Shutdown, SocketAddr};
-#[cfg(all(feature = "io_safety", unix))]
+#[cfg(all(has_io_safety, unix))]
 use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, RawSocket};
-#[cfg(all(feature = "io_safety", windows))]
+#[cfg(all(has_io_safety, windows))]
 use std::os::windows::io::{AsSocket, BorrowedSocket, OwnedSocket};
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::pin::Pin;
@@ -244,14 +244,14 @@ impl AsRawFd for TcpListener {
     }
 }
 
-#[cfg(all(feature = "io_safety", unix))]
+#[cfg(all(has_io_safety, unix))]
 impl AsFd for TcpListener {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.inner.get_ref().as_fd()
     }
 }
 
-#[cfg(all(feature = "io_safety", unix))]
+#[cfg(all(has_io_safety, unix))]
 impl TryFrom<OwnedFd> for TcpListener {
     type Error = io::Error;
 
@@ -267,14 +267,14 @@ impl AsRawSocket for TcpListener {
     }
 }
 
-#[cfg(all(feature = "io_safety", windows))]
+#[cfg(all(has_io_safety, windows))]
 impl AsSocket for TcpListener {
     fn as_socket(&self) -> BorrowedSocket<'_> {
         self.inner.get_ref().as_socket()
     }
 }
 
-#[cfg(all(feature = "io_safety", windows))]
+#[cfg(all(has_io_safety, windows))]
 impl TryFrom<OwnedSocket> for TcpListener {
     type Error = io::Error;
 
@@ -610,14 +610,14 @@ impl AsRawFd for TcpStream {
     }
 }
 
-#[cfg(all(feature = "io_safety", unix))]
+#[cfg(all(has_io_safety, unix))]
 impl AsFd for TcpStream {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.inner.get_ref().as_fd()
     }
 }
 
-#[cfg(all(feature = "io_safety", unix))]
+#[cfg(all(has_io_safety, unix))]
 impl TryFrom<OwnedFd> for TcpStream {
     type Error = io::Error;
 
@@ -633,14 +633,14 @@ impl AsRawSocket for TcpStream {
     }
 }
 
-#[cfg(all(feature = "io_safety", windows))]
+#[cfg(all(has_io_safety, windows))]
 impl AsSocket for TcpStream {
     fn as_socket(&self) -> BorrowedSocket<'_> {
         self.inner.get_ref().as_socket()
     }
 }
 
-#[cfg(all(feature = "io_safety", windows))]
+#[cfg(all(has_io_safety, windows))]
 impl TryFrom<OwnedSocket> for TcpStream {
     type Error = io::Error;
 

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -1,13 +1,13 @@
 use std::convert::TryFrom;
 use std::io;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
-#[cfg(all(feature = "io_safety", unix))]
+#[cfg(all(has_io_safety, unix))]
 use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, RawSocket};
-#[cfg(all(feature = "io_safety", windows))]
+#[cfg(all(has_io_safety, windows))]
 use std::os::windows::io::{AsSocket, BorrowedSocket, OwnedSocket};
 use std::sync::Arc;
 
@@ -627,14 +627,14 @@ impl AsRawFd for UdpSocket {
     }
 }
 
-#[cfg(all(feature = "io_safety", unix))]
+#[cfg(all(has_io_safety, unix))]
 impl AsFd for UdpSocket {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.inner.get_ref().as_fd()
     }
 }
 
-#[cfg(all(feature = "io_safety", unix))]
+#[cfg(all(has_io_safety, unix))]
 impl TryFrom<OwnedFd> for UdpSocket {
     type Error = io::Error;
 
@@ -650,14 +650,14 @@ impl AsRawSocket for UdpSocket {
     }
 }
 
-#[cfg(all(feature = "io_safety", windows))]
+#[cfg(all(has_io_safety, windows))]
 impl AsSocket for UdpSocket {
     fn as_socket(&self) -> BorrowedSocket<'_> {
         self.inner.get_ref().as_socket()
     }
 }
 
-#[cfg(all(feature = "io_safety", windows))]
+#[cfg(all(has_io_safety, windows))]
 impl TryFrom<OwnedSocket> for UdpSocket {
     type Error = io::Error;
 

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -1,13 +1,13 @@
 use std::convert::TryFrom;
 use std::io;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
-#[cfg(all(has_io_safety, unix))]
+#[cfg(all(not(async_net_no_io_safety), unix))]
 use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, RawSocket};
-#[cfg(all(has_io_safety, windows))]
+#[cfg(all(not(async_net_no_io_safety), windows))]
 use std::os::windows::io::{AsSocket, BorrowedSocket, OwnedSocket};
 use std::sync::Arc;
 
@@ -627,14 +627,14 @@ impl AsRawFd for UdpSocket {
     }
 }
 
-#[cfg(all(has_io_safety, unix))]
+#[cfg(all(not(async_net_no_io_safety), unix))]
 impl AsFd for UdpSocket {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.inner.get_ref().as_fd()
     }
 }
 
-#[cfg(all(has_io_safety, unix))]
+#[cfg(all(not(async_net_no_io_safety), unix))]
 impl TryFrom<OwnedFd> for UdpSocket {
     type Error = io::Error;
 
@@ -650,14 +650,14 @@ impl AsRawSocket for UdpSocket {
     }
 }
 
-#[cfg(all(has_io_safety, windows))]
+#[cfg(all(not(async_net_no_io_safety), windows))]
 impl AsSocket for UdpSocket {
     fn as_socket(&self) -> BorrowedSocket<'_> {
         self.inner.get_ref().as_socket()
     }
 }
 
-#[cfg(all(has_io_safety, windows))]
+#[cfg(all(not(async_net_no_io_safety), windows))]
 impl TryFrom<OwnedSocket> for UdpSocket {
     type Error = io::Error;
 

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -1,10 +1,14 @@
 use std::convert::TryFrom;
 use std::io;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+#[cfg(all(feature = "io_safety", unix))]
+use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, RawSocket};
+#[cfg(all(feature = "io_safety", windows))]
+use std::os::windows::io::{AsSocket, BorrowedSocket, OwnedSocket};
 use std::sync::Arc;
 
 use async_io::Async;
@@ -623,9 +627,41 @@ impl AsRawFd for UdpSocket {
     }
 }
 
+#[cfg(all(feature = "io_safety", unix))]
+impl AsFd for UdpSocket {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.inner.get_ref().as_fd()
+    }
+}
+
+#[cfg(all(feature = "io_safety", unix))]
+impl TryFrom<OwnedFd> for UdpSocket {
+    type Error = io::Error;
+
+    fn try_from(value: OwnedFd) -> Result<Self, Self::Error> {
+        Self::try_from(std::net::UdpSocket::from(value))
+    }
+}
+
 #[cfg(windows)]
 impl AsRawSocket for UdpSocket {
     fn as_raw_socket(&self) -> RawSocket {
         self.inner.as_raw_socket()
+    }
+}
+
+#[cfg(all(feature = "io_safety", windows))]
+impl AsSocket for UdpSocket {
+    fn as_socket(&self) -> BorrowedSocket<'_> {
+        self.inner.get_ref().as_socket()
+    }
+}
+
+#[cfg(all(feature = "io_safety", windows))]
+impl TryFrom<OwnedSocket> for UdpSocket {
+    type Error = io::Error;
+
+    fn try_from(value: OwnedSocket) -> Result<Self, Self::Error> {
+        Self::try_from(std::net::UdpSocket::from(value))
     }
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -6,6 +6,8 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::io::{self, Read as _, Write as _};
 use std::net::Shutdown;
+#[cfg(feature = "io_safety")]
+use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(windows)]
@@ -169,6 +171,22 @@ impl From<UnixListener> for Arc<Async<std::os::unix::net::UnixListener>> {
 impl AsRawFd for UnixListener {
     fn as_raw_fd(&self) -> RawFd {
         self.inner.as_raw_fd()
+    }
+}
+
+#[cfg(all(feature = "io_safety", unix))]
+impl AsFd for UnixListener {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.inner.get_ref().as_fd()
+    }
+}
+
+#[cfg(all(feature = "io_safety", unix))]
+impl TryFrom<OwnedFd> for UnixListener {
+    type Error = io::Error;
+
+    fn try_from(value: OwnedFd) -> Result<Self, Self::Error> {
+        Self::try_from(std::os::unix::net::UnixListener::from(value))
     }
 }
 
@@ -368,6 +386,22 @@ impl From<UnixStream> for Arc<Async<std::os::unix::net::UnixStream>> {
 impl AsRawFd for UnixStream {
     fn as_raw_fd(&self) -> RawFd {
         self.inner.as_raw_fd()
+    }
+}
+
+#[cfg(all(feature = "io_safety", unix))]
+impl AsFd for UnixStream {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.inner.get_ref().as_fd()
+    }
+}
+
+#[cfg(all(feature = "io_safety", unix))]
+impl TryFrom<OwnedFd> for UnixStream {
+    type Error = io::Error;
+
+    fn try_from(value: OwnedFd) -> Result<Self, Self::Error> {
+        Self::try_from(std::os::unix::net::UnixStream::from(value))
     }
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -6,7 +6,7 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::io::{self, Read as _, Write as _};
 use std::net::Shutdown;
-#[cfg(feature = "io_safety")]
+#[cfg(has_io_safety)]
 use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -174,14 +174,14 @@ impl AsRawFd for UnixListener {
     }
 }
 
-#[cfg(all(feature = "io_safety", unix))]
+#[cfg(all(has_io_safety, unix))]
 impl AsFd for UnixListener {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.inner.get_ref().as_fd()
     }
 }
 
-#[cfg(all(feature = "io_safety", unix))]
+#[cfg(all(has_io_safety, unix))]
 impl TryFrom<OwnedFd> for UnixListener {
     type Error = io::Error;
 
@@ -389,14 +389,14 @@ impl AsRawFd for UnixStream {
     }
 }
 
-#[cfg(all(feature = "io_safety", unix))]
+#[cfg(all(has_io_safety, unix))]
 impl AsFd for UnixStream {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.inner.get_ref().as_fd()
     }
 }
 
-#[cfg(all(feature = "io_safety", unix))]
+#[cfg(all(has_io_safety, unix))]
 impl TryFrom<OwnedFd> for UnixStream {
     type Error = io::Error;
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -6,7 +6,7 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::io::{self, Read as _, Write as _};
 use std::net::Shutdown;
-#[cfg(has_io_safety)]
+#[cfg(not(async_net_no_io_safety))]
 use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -174,14 +174,14 @@ impl AsRawFd for UnixListener {
     }
 }
 
-#[cfg(all(has_io_safety, unix))]
+#[cfg(all(not(async_net_no_io_safety), unix))]
 impl AsFd for UnixListener {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.inner.get_ref().as_fd()
     }
 }
 
-#[cfg(all(has_io_safety, unix))]
+#[cfg(all(not(async_net_no_io_safety), unix))]
 impl TryFrom<OwnedFd> for UnixListener {
     type Error = io::Error;
 
@@ -389,14 +389,14 @@ impl AsRawFd for UnixStream {
     }
 }
 
-#[cfg(all(has_io_safety, unix))]
+#[cfg(all(not(async_net_no_io_safety), unix))]
 impl AsFd for UnixStream {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.inner.get_ref().as_fd()
     }
 }
 
-#[cfg(all(has_io_safety, unix))]
+#[cfg(all(not(async_net_no_io_safety), unix))]
 impl TryFrom<OwnedFd> for UnixStream {
     type Error = io::Error;
 


### PR DESCRIPTION
This PR adds a new feature, `io_safety`, which requires Rust 1.63. With this feature, the types in this crate implement `AsFd/AsSocket` and `TryFrom<OwnedFd/OwnedSocket>`.

See also: sunfishcode/io-lifetimes#38

Should I also implement `TryInto<OwnedFd/OwnedSocket>` on these types? It would involve unwrapping the `Arc`, which doesn't feel idiomatic, but it would complete the symmetry with `std`.