### PR TITLE
Migrate to Rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "async-net"
 # - Create "v1.x.y" git tag
 version = "1.8.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.63"
 description = "Async networking primitives for TCP/UDP/Unix communication"
 license = "Apache-2.0 OR MIT"

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::fmt;
 use std::io::{self, IoSlice, Read as _, Write as _};
 use std::net::{Shutdown, SocketAddr};

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::io;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 #[cfg(unix)]

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -2,7 +2,6 @@
 //!
 //! This module is an async version of [`std::os::unix::net`].
 
-use std::convert::TryFrom;
 use std::fmt;
 use std::io::{self, Read as _, Write as _};
 use std::net::Shutdown;


### PR DESCRIPTION
Our MSRV (1.63) is higher than 1.56 that Rust 2021 was stabilized.