### PR TITLE
Bump to async-io v2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ categories = ["asynchronous", "network-programming", "os"]
 exclude = ["/.*"]
 
 [dependencies]
-async-io = "1.6.0"
+async-io = "2.0.0"
 blocking = "1.0.0"
 futures-lite = "1.11.0"


### PR DESCRIPTION
As async-io is a public dependency of this crate, this is a breaking change.