### PR TITLE
v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 2.0.0
+
+- **Breaking:** Bump `async-io` to version 2.0.0. (#28)
+- Bump `futures-lite` to version 2.0.0. (#29)
+
 # Version 1.8.0
 
 - Bump MSRV to 1.63. (#23)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "async-net"
 # When publishing a new version:
 # - Update CHANGELOG.md
-# - Create "v1.x.y" git tag
-version = "1.8.0"
+# - Create "v2.x.y" git tag
+version = "2.0.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- **Breaking:** Bump `async-io` to version 2.0.0. (#28)
- Bump `futures-lite` to version 2.0.0. (#29)
